### PR TITLE
Feat/mypage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-oauth/google": "^0.12.2",
         "@tailwindcss/vite": "^4.1.11",
         "axios": "^1.11.0",
+        "lucide-react": "^0.537.0",
         "motion": "^12.23.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -4797,6 +4798,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.537.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.537.0.tgz",
+      "integrity": "sha512-VxWsdxBGeFnlC+HwMg/l08HptN4YRU9o/lRog156jOmRxI1ERKqN+rJiNY/mPcKAdWdM0UbyO8ft1o0jq69SSQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-oauth/google": "^0.12.2",
     "@tailwindcss/vite": "^4.1.11",
     "axios": "^1.11.0",
+    "lucide-react": "^0.537.0",
     "motion": "^12.23.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,26 +1,25 @@
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import Login from './pages/Login';
-import Layout from './Layouts/layout';
+import Layout from './layouts/Layout';
 import { useState } from 'react';
 import OAuthCallback from './pages/OAuthCallback';
 import AddInfo from './pages/AddInfo';
+import MyPage from './pages/MyPage';
 
 function App() {
-  // eslint-disable-next-line no-unused-vars
-  const [isLogin, _setIsLogin] = useState(false);
+  const [isLogin, setIsLogin] = useState(false);
+
   return (
-    <>
-      <Routes>
-        <Route element={<Layout isLogin={isLogin} />}>
-          <Route path="/" element={<Home />} />
-        </Route>
+    <Routes>
+      <Route element={<Layout isLogin={isLogin} setIsLogin={setIsLogin} />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/mypage" element={<MyPage />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/auth/callback" element={<OAuthCallback />} />
         <Route path="/add-info" element={<AddInfo />} />
-      </Routes>
-    </>
+        <Route path="/auth/callback" element={<OAuthCallback />} />
+      </Route>
+    </Routes>
   );
 }
-
 export default App;

--- a/src/Layouts/Layout.jsx
+++ b/src/Layouts/Layout.jsx
@@ -1,15 +1,19 @@
-import { Outlet } from 'react-router-dom';
-import NavBar from '../components/NavBar';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import NavBar from '@/components/NavBar';
 
-function Layout({ isLogin }) {
+export default function Layout() {
+  const [user, setUser] = useState(null);
+  const navigate = useNavigate();
+  const onLogout = () => {
+    setUser(null);
+    navigate('/', { replace: true });
+  };
+
   return (
     <>
-      <NavBar isLogin={isLogin} />
-      <main>
-        <Outlet />
-      </main>
+      <NavBar isLogin={!!user} onLogout={onLogout} />
+      <Outlet context={{ setUser }} />
     </>
   );
 }
-
-export default Layout;

--- a/src/components/MyPageForm.jsx
+++ b/src/components/MyPageForm.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+import CustomInput from '@/components/CustomInput';
+
+export default function MyPageForm({
+  email = '-',
+  riotAccounts = [],
+  onAddRiot, // 플러스 버튼 클릭 핸들러
+  onRemoveRiot, // 삭제 버튼 핸들러(옵션)
+}) {
+  return (
+    <form className="space-y-16" onSubmit={(e) => e.preventDefault()}>
+      {/* 기본정보 */}
+      <section className="space-y-3">
+        <h3 className="text-sm text-[#a7a7a7]">기본정보</h3>
+        <div className="w-full max-w-md">
+          <CustomInput
+            label="E-mail"
+            value={email ?? '-'}
+            readOnly
+            className="bg-[#3A3A3A] border-[#575757] rounded-xl px-5"
+          />
+        </div>
+      </section>
+
+      {/* 회원 정보 추가 */}
+      <section className="space-y-2">
+        <h3 className="text-sm text-[#a7a7a7]">회원 정보 추가</h3>
+        <Link
+          to="/add-info"
+          className="text-[#22c1a3] hover:underline font-semibold"
+        >
+          추가 정보 입력
+        </Link>
+      </section>
+
+      {/* 연결된 계정 */}
+      <section className="space-y-4">
+        <h3 className="text-sm text-[#a7a7a7]">연결된 계정</h3>
+
+        <div className="bg-[#3A3A3A] border border-[#575757] rounded-3xl p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h4 className="text-xl font-bold">라이엇 게임즈</h4>
+
+            <button
+              type="button"
+              onClick={onAddRiot}
+              aria-label="라이엇 계정 추가"
+              className="relative inline-flex items-center justify-center w-10 h-10
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/70
+                          transition-transform hover:scale-110 active:scale-95"
+            >
+              <Plus
+                className="w-6 h-6 drop-shadow-[0_0_10px_rgba(34,193,163,0.85)] cursor-pointer"
+                strokeWidth={2.25}
+              />
+              <span className="sr-only">라이엇 계정 추가</span>
+            </button>
+          </div>
+
+          <ul className="space-y-2 list-none">
+            {riotAccounts.length === 0 ? (
+              <li className="text-sm text-[#bdbdbd]">
+                연결된 계정이 없습니다.
+              </li>
+            ) : (
+              riotAccounts.map((acct, i) => (
+                <li
+                  key={`${acct}-${i}`}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="tracking-wide">
+                    {i + 1}. {acct}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onRemoveRiot?.(i)}
+                    disabled={!onRemoveRiot}
+                    className={`text-[#e0e0e0] ${onRemoveRiot ? 'hover:underline' : 'opacity-60 cursor-pointer'}`}
+                  >
+                    삭제
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      </section>
+
+      {/* 회원 탈퇴 (모양만) */}
+      <div className="pt-4 border-t border-[#575757] flex justify-end">
+        <button
+          type="button"
+          disabled
+          className="px-4 py-2 rounded-md bg-[#3F3E3E] border border-[#787878] text-[#eaeaea]
+                      hover:bg-[#4a4949] hover:border-[#a0a0a0] cursor-not-allowed"
+        >
+          회원 탈퇴
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -2,13 +2,14 @@ import NavBarLinkStyle from './NavBarLinkStyle';
 import Logo from '../assets/logo.svg?react';
 import { useNavigate } from 'react-router-dom';
 
-function NavBar({ isLogin }) {
+function NavBar({ isLogin, onLogout }) {
   const navItems = [
     { label: '팀원 찾기', path: '/' },
     { label: '랭킹', path: '/' },
     { label: '챔피언', path: '/' },
   ];
   const navigate = useNavigate();
+
   return (
     <div className="w-screen h-[90px] bg-[#232323] text-white flex items-center px-6">
       <div className="flex items-center justify-center text-white font-bold text-2xl h-full w-[100px] pr-6">
@@ -21,9 +22,14 @@ function NavBar({ isLogin }) {
           </NavBarLinkStyle>
         ))}
       </div>
-      <div className="flex h-full ml-auto ">
+      <div className="flex h-full ml-auto gap-2">
+        {' '}
+        {/* ← gap으로 간격 */}
         {isLogin ? (
-          <NavBarLinkStyle to="/login">마이페이지</NavBarLinkStyle>
+          <>
+            <NavBarLinkStyle to="/mypage">마이페이지</NavBarLinkStyle>
+            <NavBarLinkStyle onClick={onLogout}>로그아웃</NavBarLinkStyle>
+          </>
         ) : (
           <NavBarLinkStyle to="/login">로그인</NavBarLinkStyle>
         )}

--- a/src/components/NavBarLinkStyle.jsx
+++ b/src/components/NavBarLinkStyle.jsx
@@ -1,7 +1,20 @@
 import { Link } from 'react-router-dom';
 import { motion } from 'motion/react';
 
-function NavBarLinkStyle({ to, children }) {
+function NavBarLinkStyle({ to, onClick, children }) {
+  const content = (
+    <>
+      {/* 텍스트 위로 살짝 이동 */}
+      <motion.span
+        className="inline-block"
+        variants={{ rest: { y: 0 }, hover: { y: -10 } }}
+        transition={{ type: 'spring', stiffness: 500, damping: 30, mass: 0.3 }}
+      >
+        {children}
+      </motion.span>
+    </>
+  );
+
   return (
     <motion.div
       className="relative flex items-end justify-center text-white w-[80px] pb-3 cursor-pointer"
@@ -9,18 +22,24 @@ function NavBarLinkStyle({ to, children }) {
       whileHover="hover"
       animate="rest"
     >
+      {/* 호버 배경 */}
       <motion.div
         className="absolute inset-0"
         style={{ background: 'linear-gradient(#363636, black)' }}
-        variants={{
-          rest: { opacity: 0 },
-          hover: { opacity: 0.8 },
-        }}
+        variants={{ rest: { opacity: 0 }, hover: { opacity: 0.8 } }}
         transition={{ duration: 0.3 }}
       />
-      <Link to={to} className="relative z-10">
-        {children}
-      </Link>
+
+      {/* 링크 or 버튼 – 안쪽 내용은 공통 */}
+      {to ? (
+        <Link to={to} className="relative z-10">
+          {content}
+        </Link>
+      ) : (
+        <button type="button" onClick={onClick} className="relative z-10">
+          {content}
+        </button>
+      )}
     </motion.div>
   );
 }

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import MyPageForm from '@/components/MyPageForm';
+
+export default function MyPage() {
+  const navigate = useNavigate();
+
+  // 더미 데이터 (백엔드 붙기 전)
+  const email = 'social@example.com';
+  const riotAccounts = ['소환사A#1234', '소환사B#7777', '소환사C#99999'];
+
+  return (
+    <main className="min-h-screen w-full bg-[#141414] text-white">
+      <div className="max-w-[900px] mx-auto px-6 py-10">
+        <MyPageForm
+          email={email}
+          riotAccounts={riotAccounts}
+          onAddRiot={() => navigate('/connect/riot')}
+          // onRemoveRiot={(index) => ...}             // 나중에 API 붙으면 구현
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -1,10 +1,22 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import {
+  useNavigate,
+  useSearchParams,
+  useOutletContext,
+} from 'react-router-dom';
 
 export default function OAuthCallback() {
+  const [params] = useSearchParams();
   const navigate = useNavigate();
+  const { setUser } = useOutletContext(); // ← 이제 null 아님
+
   useEffect(() => {
-    navigate('/');
-  }, [navigate]);
-  return <div>로그인 처리 중입니다...</div>;
+    const code = params.get('code');
+    if (!code) return navigate('/login?error=missing_code', { replace: true });
+
+    setUser({ email: 'social@example.com' });
+    navigate('/', { replace: true });
+  }, [params, navigate, setUser]);
+
+  return <div>로그인 처리 중…</div>;
 }


### PR DESCRIPTION
# 🚀 PR 요약
소셜 로그인 콜백 처리 추가 및 마이페이지 UI 1차 적용(네비게이션/로그아웃 포함)

## ✏️ 변경 유형
- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [x] style: 코드 포맷팅/스타일 변경
- [x] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [x] chore: 기타 변경사항(환경설정 등)
- [ ] remove: 코드/파일 제거
- [ ] hotfix: 급한 버그 패치
- [x] design: UI/디자인 관련 변경

## 변경 요약(하이라이트)
- OAuth 콜백 페이지에서 `code` 파싱 → (향후 교환) → 유저 세팅 → **클린 리다이렉트** 플로우 도입
- **마이페이지(MyPage)** UI 구성 및 `MyPageForm`로 폼/페이지 분리
- **NavBar**: 로그인 시 `마이페이지` + `로그아웃` 동시 노출
- **NavBarLinkStyle**: 링크/버튼 공용화 + 호버 애니메이션(텍스트 상승, 밑줄)
- **Layout**: `NavBar isLogin`/`onLogout` 연결 및 `<Outlet context={{ setUser }}>`로 하위 라우트에 로그인 setter 전달
- 의존성: `lucide-react` 추가

## ✅ 체크리스트
- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 테스트 방법(간단)
1. 소셜 로그인 진행 → `/auth/callback?code=...` 도착 시
2. 콜백에서 `setUser` 호출 후 홈(또는 `/mypage`)로 이동하는지 확인
3. NavBar 우측에 **마이페이지 · 로그아웃** 동시 노출 확인
4. 로그아웃 클릭 시 홈으로 이동 및 우측에 **로그인**으로 복귀 확인
5. 마이페이지 UI 노출 및 더미 데이터 렌더링 확인

## 🗒️ 기타 참고사항
- 현재 콜백은 임시로 `setUser({ email: 'social@example.com' })` 사용 → 백엔드 토큰 교환 후 실제 프로필로 교체 필요
- `lucide-react` 아이콘 사용(빌드 환경 확인)
- 라우트 중첩: `/auth/callback`이 **Layout 내부**에 있어야 `Outlet context` 접근 가능

